### PR TITLE
test: use non-destructive runner for readonly suite

### DIFF
--- a/tests/post_deploy_functional_readonly/main_test.go
+++ b/tests/post_deploy_functional_readonly/main_test.go
@@ -33,5 +33,5 @@ func TestSkeletonModule(t *testing.T) {
 		SetTestConfigFileName(infraTFVarFileNameDefault).
 		Build()
 
-	lib.RunSetupTestTeardown(t, *ctx, testimpl.TestComposableComplete)
+	lib.RunNonDestructiveTest(t, *ctx, testimpl.TestComposableComplete)
 }


### PR DESCRIPTION
## What

The `tests/post_deploy_functional_readonly` suite called `lib.RunSetupTestTeardown`, which **applies and destroys** infrastructure — so the "read-only" suite was not actually read-only. This switches it to `lib.RunNonDestructiveTest`.

## Why it was invisible

`make test` excludes `post_deploy_functional_readonly` (`go list ./tests/... | grep -v post_deploy_functional_readonly`), so CI never runs this suite and the wrong runner passed unnoticed. Background: launchbynttdata/launch-workflows#92.

## Scope / safety

- One-line change. The testimpl function (`testimpl.TestComposableComplete`) is **unchanged** and already satisfies the `TestComposable*` requirement of `RunNonDestructiveTest`.
- This is the proven-correct pairing used by passing modules across the fleet.
- Non-blocking note: the outer test func is still named `TestSkeletonModule` (skeleton leftover) — left as-is to keep this change minimal.

Part of a fleet-wide cleanup; this is the first (pilot) of the converted-cohort "wrong runner" repos.

Generated with [Claude Code](https://claude.com/claude-code)